### PR TITLE
workflows: add contibutor license agreement checker

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,29 @@
+name: Verify Contributor License Agreement
+
+on: [pull_request]
+
+jobs:
+  cla-validate:
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - run: |
+        echo "::set-env name=CLA_SIGNED::$(grep -q ${{ github.actor }} ./tools/.lp-to-git-user && echo CLA signed || echo CLA not signed)"
+    - name: Add CLA label
+      run: |
+        # POST a new label to this issue
+        curl --request POST \
+        --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/labels \
+        --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+        --header 'content-type: application/json' \
+        --data '{"labels": ["${{env.CLA_SIGNED}}"]}'
+    - name: Comment about CLA signing
+      if: env.CLA_SIGNED == 'CLA not signed'
+      run: |
+        # POST a comment directing submitter to sign the CLA
+        curl --request POST \
+        --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/comments \
+        --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+        --header 'content-type: application/json' \
+        --data '{"body": "Hello ${{ github.actor }},\n\nThank you for your contribution to cloud-init.\n\nIn order for us to merge this pull request, you need\nto have signed the Contributor License Agreement (CLA).\nPlease ensure that you have signed the CLA by following our\nhacking guide at:\n\nhttps://cloudinit.readthedocs.io/en/latest/topics/hacking.html\n\nThanks,\nYour friendly cloud-init upstream\n"}'

--- a/doc/examples/cloud-config-update-apt.txt
+++ b/doc/examples/cloud-config-update-apt.txt
@@ -5,4 +5,4 @@
 #
 # Default: false
 # Aliases: apt_update
-package_update: false
+package_update: true

--- a/doc/rtd/topics/modules.rst
+++ b/doc/rtd/topics/modules.rst
@@ -1,8 +1,11 @@
 .. _modules:
 
+
 *******
 Modules
 *******
+.. contents:: Table of Contents
+
 .. automodule:: cloudinit.config.cc_apt_configure
 .. automodule:: cloudinit.config.cc_apt_pipelining
 .. automodule:: cloudinit.config.cc_bootcmd


### PR DESCRIPTION
Check whether the pull request submitter has signed the CLA due
to presence of github.actor in tools/.lp-to-git-user

Set 'CLA signed' if present, 'CLA not signed' label if absent