### PR TITLE
workflows: introduce stale pull request workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,8 @@
 name: Mark and close stale pull requests
 
-on:
-  schedule:
-  - cron: "0 0 * * *"  # Daily @ 00:00
+on: [pull_request]
+#  schedule:
+#  - cron: "0 0 * * *"  # Daily @ 00:00
 
 jobs:
   stale:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: Mark and close stale pull requests
+
+on:
+  schedule:
+  - cron: "0 0 * * *"  # Daily @ 00:00
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-stale: 14
+        days-before-close: 7
+        stale-pr-message: |
+          Hello! Thank you for this proposed change to cloud-init. This pull request is now marked as stale as it has not seen any activity in 14 days. If no activity occurs within the next 7 days, this pull request will automatically close.
+
+          (If the pull request is closed, please do feel free to reopen it if you wish to continue working on it.)
+        stale-pr-label: 'stale-pr'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,8 @@
 name: Mark and close stale pull requests
 
-on: [pull_request]
-#  schedule:
-#  - cron: "0 0 * * *"  # Daily @ 00:00
+on:
+  schedule:
+  - cron: "*/5 0 * * *"  # Daily @ 00:00
 
 jobs:
   stale:


### PR DESCRIPTION
This workflow will label pull requests with "stale-pr" if they haven't
seen activity for 14 days.  It will then close them out after a further
7 days of inactivity.